### PR TITLE
Update tissue to only show options available for the selected phenotype

### DIFF
--- a/R/mod_pathology.R
+++ b/R/mod_pathology.R
@@ -44,6 +44,17 @@ mod_pathology_ui <- function(id) {
 mod_pathology_server <- function(input, output, session) {
   ns <- session$ns
 
+  observeEvent(input$phenotype, {
+    phenotype_data <- dplyr::filter(magora::phenotypes, .data$phenotype == input$phenotype)
+    available_tissue <- unique(phenotype_data[["tissue"]])
+
+    shinyWidgets::updatePickerInput(
+      session = session,
+      "tissue",
+      choices = available_tissue
+    )
+  })
+
   filtered_phenotypes <- shiny::reactive({
     shiny::validate(
       shiny::need(!is.null(input$mouse_line), message = "Please select one or more mouse lines.")

--- a/R/mod_pathology.R
+++ b/R/mod_pathology.R
@@ -64,6 +64,8 @@ mod_pathology_server <- function(input, output, session) {
   })
 
   output$phenotype_plot <- shiny::renderPlot({
+    shiny::req(nrow(filtered_phenotypes()) > 0)
+
     filtered_phenotypes() %>%
       expand_mouse_line_factor(input$mouse_line) %>%
       plot_phenotypes()


### PR DESCRIPTION
Closes #8.

Only show options for Tissue that actually have data for the selected phenotype:

![Screen Shot 2020-06-26 at 2 45 55 PM (2)](https://user-images.githubusercontent.com/15895337/85890747-fb3bf780-b7bb-11ea-8d44-2ff4770c096c.png)

![Screen Shot 2020-06-26 at 2 45 45 PM (2)](https://user-images.githubusercontent.com/15895337/85890752-fc6d2480-b7bb-11ea-986b-082f3a6dd081.png)

For now I've also stopped the plot from rendering when there's no data because it still throws the same error, but this only happens very quickly due to the error of execution (e.g. tissue is "cortex" and phenotype is changed to "Plasma AB 40", then the plot renders before the tissue options are updated). Again, if it comes up that there's a real case where there's no data (e.g. mouse lines) oand we want to display some message about it, I'll revisit handling the order of execution.