### PR TITLE
Switch r-devel testing to linux

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel',   vdiffr: false}
           - {os: macOS-latest,   r: 'release', vdiffr: true}
           - {os: windows-latest, r: 'release', vdiffr: true}
+          - {os: ubuntu-16.04,   r: 'devel',   vdiffr: false, rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'release', vdiffr: true,  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'oldrel',  vdiffr: false, rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',     vdiffr: false, rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}


### PR DESCRIPTION
Testing on r-devel on macOS is still broken, but it's now possible to do so on linux. This should fix our GHA builds and hopefully will be more robust than the mac testing.