### PR TITLE
Make wording of no data for gene expressions more accurate

### DIFF
--- a/R/magora_boxplot.R
+++ b/R/magora_boxplot.R
@@ -13,7 +13,10 @@ magora_boxplot <- function(data, plot_type = c("phenotype", "gene expression"), 
   measured_annotation <- data %>%
     dplyr::count(.data$mouse_line, .drop = FALSE) %>%
     dplyr::filter(.data$n == 0) %>%
-    dplyr::mutate(label = paste("This", plot_type, "cannot be\nmeasured in this mouse line."))
+    dplyr::mutate(label = dplyr::case_when(
+      plot_type == "phenotype" ~ "This phenotype cannot be\nmeasured in this mouse line.",
+      plot_type == "gene expression" ~ "There is no data for this combination."
+    ))
 
   # If data only contains one sex, generate fake data and set alpha and color so that boxplot legend/dodging are correct
   data <- data %>%

--- a/tests/figs/magora-boxplot/gene-expression-no-data.svg
+++ b/tests/figs/magora-boxplot/gene-expression-no-data.svg
@@ -118,8 +118,7 @@
 <polyline points='498.39,545.13 498.39,39.41 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzI5LjM2fDYyMC40N3w1NDUuMTN8MzkuNDE=)' />
 <polyline points='545.34,545.13 545.34,39.41 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzI5LjM2fDYyMC40N3w1NDUuMTN8MzkuNDE=)' />
 <polyline points='592.30,545.13 592.30,39.41 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzI5LjM2fDYyMC40N3w1NDUuMTN8MzkuNDE=)' />
-<g clip-path='url(#cpMzI5LjM2fDYyMC40N3w1NDUuMTN8MzkuNDE=)'><text x='374.14' y='286.92' style='font-size: 14.23px; font-family: Liberation Sans;' textLength='201.55px' lengthAdjust='spacingAndGlyphs'>This gene expression cannot be</text></g>
-<g clip-path='url(#cpMzI5LjM2fDYyMC40N3w1NDUuMTN8MzkuNDE=)'><text x='384.43' y='307.41' style='font-size: 14.23px; font-family: Liberation Sans;' textLength='180.97px' lengthAdjust='spacingAndGlyphs'>measured in this mouse line.</text></g>
+<g clip-path='url(#cpMzI5LjM2fDYyMC40N3w1NDUuMTN8MzkuNDE=)'><text x='357.95' y='297.16' style='font-size: 14.23px; font-family: Liberation Sans;' textLength='233.94px' lengthAdjust='spacingAndGlyphs'>There is no data for this combination.</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />


### PR DESCRIPTION
Closes #20 - for the gene expression plots, the message on facets with no data is now "There is no data for this combination".