### PR TITLE
Use latest version of {arrow} with .data pronoun

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     rlang,
     pkgload,
     shinycssloaders,
-    arrow,
+    arrow (>= 3.0.0),
     here,
     stringr,
     readr,

--- a/R/mod_gene_expression.R
+++ b/R/mod_gene_expression.R
@@ -105,14 +105,13 @@ mod_gene_expression_server <- function(input, output, session, gene_expressions)
     )
 
     gene_expressions %>%
-      # Cannot use .data pronoun because it is meaningful (for something else) in Arrow
       dplyr::filter(
-        partition == tolower(stringr::str_sub(input$gene, 1, 1)),
-        gene == input$gene,
-        tissue == input$tissue
+        .data$partition == tolower(stringr::str_sub(input$gene, 1, 1)),
+        .data$gene == input$gene,
+        .data$tissue == input$tissue,
+        .data$mouse_line %in% input$mouse_line
       ) %>%
-      dplyr::collect() %>%
-      dplyr::filter(.data$mouse_line %in% input$mouse_line) # Arrow seems to have issue with %in%, so collect, then do the last filter
+      dplyr::collect()
   })
 
   # Generate plot ----

--- a/renv.lock
+++ b/renv.lock
@@ -67,10 +67,10 @@
     },
     "arrow": {
       "Package": "arrow",
-      "Version": "2.0.0",
+      "Version": "3.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "04a9e87326777f5205bacdf3ec4ffa02"
+      "Hash": "41517f74f2e340e7ce736dd9bcfbb360"
     },
     "askpass": {
       "Package": "askpass",


### PR DESCRIPTION
The latest version of {arrow} has been released on CRAN, and it fixes the issue I was having using the `.data` pronoun 🎉 . Just a quick PR to integrate that in!