### PR TITLE
Remove ability to download data

### DIFF
--- a/R/mod_gene_expression.R
+++ b/R/mod_gene_expression.R
@@ -53,15 +53,11 @@ mod_gene_expression_ui <- function(id) {
       shiny::fluidRow(
         class = "magora-row",
         shiny::column(
-          width = 3,
-          offset = 9,
-          shiny::column(
-            width = 6,
-            mod_download_data_ui(ns("download_data"))
-          ),
+          width = 2,
+          offset = 10,
 
           shiny::column(
-            width = 6,
+            width = 12,
             mod_download_plot_ui(ns("download_plot"))
           )
         ),
@@ -162,14 +158,6 @@ mod_gene_expression_server <- function(input, output, session, gene_expressions)
   save_name <- shiny::reactive({
     download_name("gene_expression", input$gene, input$mouse_line, input$tissue)
   })
-
-  # Data
-
-  shiny::callModule(mod_download_data_server,
-    "download_data",
-    data = gene_expression_data_download,
-    save_name = save_name
-  )
 
   # Plot
 

--- a/R/mod_nanostring.R
+++ b/R/mod_nanostring.R
@@ -17,17 +17,14 @@ mod_nanostring_ui <- function(id) {
       shiny::includeMarkdown(app_sys("app", "www", "nanostring_content.md")),
       shiny::hr(),
       shiny::fluidRow(
+
         class = "magora-row",
         shiny::column(
-          width = 3,
-          offset = 9,
-          shiny::column(
-            width = 6,
-            mod_download_data_ui(ns("download_data"))
-          ),
+          width = 2,
+          offset = 10,
 
           shiny::column(
-            width = 6,
+            width = 12,
             mod_download_plot_ui(ns("download_plot"))
           )
         )
@@ -64,14 +61,6 @@ mod_nanostring_server <- function(input, output, session) {
   nanostring_plot_dims <- shiny::reactive({
     list(nrow = 2.75, ncol = 2.5)
   })
-
-  # Data
-
-  shiny::callModule(mod_download_data_server,
-    "download_data",
-    data = nanostring_data,
-    save_name = nanostring_name
-  )
 
   # Plot
 

--- a/R/mod_pathology.R
+++ b/R/mod_pathology.R
@@ -50,15 +50,11 @@ mod_pathology_ui <- function(id) {
       shiny::fluidRow(
         class = "magora-row",
         shiny::column(
-          width = 3,
-          offset = 9,
-          shiny::column(
-            width = 6,
-            mod_download_data_ui(ns("download_data"))
-          ),
+          width = 2,
+          offset = 10,
 
           shiny::column(
-            width = 6,
+            width = 12,
             mod_download_plot_ui(ns("download_plot"))
           )
         )
@@ -159,14 +155,6 @@ mod_pathology_server <- function(input, output, session) {
   save_name <- shiny::reactive({
     download_name("phenotype", input$phenotype, input$mouse_line, input$tissue)
   })
-
-  # Data
-
-  shiny::callModule(mod_download_data_server,
-    "download_data",
-    data = phenotype_data_download,
-    save_name = save_name
-  )
 
   # Plot
 


### PR DESCRIPTION
Removing the ability to download data from pages, for now, until we figure out if we're able to or what attributions we need to include with it.

One thought I had was that all the data *is* available here on github/within the package - but maybe Synapse usage rules allow for usage in open source differently than redistribution?

Edit: Also, am opting not to actually delete the `mod_download_data_ui` and `mod_download_data_server` functions, in case we want to add them back in.