### PR TITLE
Fix size of text on nanostring page

### DIFF
--- a/R/mod_nanostring.R
+++ b/R/mod_nanostring.R
@@ -13,11 +13,12 @@ mod_nanostring_ui <- function(id) {
     title,
     shiny::div(
       class = "magora-page",
-      shiny::h3(class = "tab-title", title),
-      shiny::includeMarkdown(app_sys("app", "www", "nanostring_content.md")),
-      shiny::hr(),
+      shiny::div(
+        shiny::h3(class = "tab-title", title),
+        shiny::includeMarkdown(app_sys("app", "www", "nanostring_content.md")),
+        shiny::hr()
+      ),
       shiny::fluidRow(
-
         class = "magora-row",
         shiny::column(
           width = 2,


### PR DESCRIPTION
Of course, now that the app is deployed I see an inconsistency!

The text on the nanostring is larger than the text of the rest of the pages, since it's right inside a div with class "magora-page" (which has a larger font size), instead of in a div() of its own (like the rest of the pages).

Don't think we need to redeploy or anything, but figured I'd fix this while it's fresh!