### PR TITLE
Exclude inputs from bookmark

### DIFF
--- a/R/mod_gene_expression_heatmap.R
+++ b/R/mod_gene_expression_heatmap.R
@@ -125,7 +125,7 @@ mod_gene_expression_heatmap_server <- function(input, output, session, gene_expr
 
   # Set up bookmarking ----
   shiny::observeEvent(input$bookmark, {
-    bookmark_query <- construct_bookmark("GeneExpressionHeatmap", input, session)
+    bookmark_query <- construct_bookmark("GeneExpressionHeatmap", input, session, exclude = "gene_expression_all-details")
     shiny:::showBookmarkUrlModal(bookmark_query)
   })
 

--- a/R/mod_gene_expression_volcano.R
+++ b/R/mod_gene_expression_volcano.R
@@ -106,7 +106,7 @@ mod_gene_expression_volcano_server <- function(input, output, session, gene_expr
 
   # Set up bookmarking ----
   shiny::observeEvent(input$bookmark, {
-    bookmark_query <- construct_bookmark("GeneExpressionVolcano", input, session, exclude = "plot_click")
+    bookmark_query <- construct_bookmark("GeneExpressionVolcano", input, session, exclude = c("gene_expression_all-details", "plot_click"))
     shiny:::showBookmarkUrlModal(bookmark_query)
   })
 

--- a/R/mod_nanostring.R
+++ b/R/mod_nanostring.R
@@ -109,7 +109,7 @@ mod_nanostring_server <- function(input, output, session) {
 
   # Set up bookmarking ----
   shiny::observeEvent(input$bookmark, {
-    bookmark_query <- construct_bookmark("Nanostring", input, session)
+    bookmark_query <- construct_bookmark("Nanostring", input, session, exclude = "nanostring-details")
     shiny:::showBookmarkUrlModal(bookmark_query)
   })
 

--- a/R/mod_pathology.R
+++ b/R/mod_pathology.R
@@ -118,7 +118,7 @@ mod_pathology_server <- function(input, output, session) {
 
   # Set up bookmarking ----
   shiny::observeEvent(input$bookmark, {
-    bookmark_query <- construct_bookmark("Pathology", input, session)
+    bookmark_query <- construct_bookmark("Pathology", input, session, exclude = c("pathology-details", "plot_click"))
     shiny:::showBookmarkUrlModal(bookmark_query)
   })
 


### PR DESCRIPTION
Excluding any "details" inputs from bookmarks (this just tracks the "more details" modal), and the input that keeps track of clicking the plot in the pathology page to open up the interactive version.

Closes #74.