### PR TITLE
Update version of shinycssloaders to fixed bouncy plots issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     magrittr,
     rlang,
     pkgload,
-    shinycssloaders,
+    shinycssloaders (>= 1.0.0.9000),
     here,
     stringr,
     readr,
@@ -49,7 +49,8 @@ Depends:
 URL: https://github.com/Sage-Bionetworks/magora
 BugReports: https://github.com/Sage-Bionetworks/magora/issues
 Remotes: 
-    Sage-Bionetworks/sagethemes@main
+    Sage-Bionetworks/sagethemes@main,
+    daattali/shinycssloaders
 Suggests: 
     testthat,
     vdiffr

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.0.2",
+    "Version": "4.1.0",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -508,10 +508,10 @@
     },
     "magrittr": {
       "Package": "magrittr",
-      "Version": "1.5",
+      "Version": "2.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1bb58822a20301cee84a41678e25d9b7"
+      "Hash": "cdc87ecd81934679d1557633d8e1fe51"
     },
     "markdown": {
       "Package": "markdown",
@@ -561,6 +561,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "49f7258fd86ebeaea1df24d9ded00478"
+    },
+    "patchwork": {
+      "Package": "patchwork",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c446b30cb33ec125ff02588b60660ccb"
     },
     "pillar": {
       "Package": "pillar",
@@ -779,10 +786,15 @@
     },
     "shinycssloaders": {
       "Package": "shinycssloaders",
-      "Version": "1.0.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "f39bb3c44a9b496723ec7e86f9a771d8"
+      "Version": "1.0.0.9000",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "shinycssloaders",
+      "RemoteUsername": "daattali",
+      "RemoteRef": "master",
+      "RemoteSha": "f031aa2cd3aa32e1efee0605639ef784e2449b04",
+      "Hash": "4e92c69965f49b28e5f833601c6e6cb9"
     },
     "shinyjs": {
       "Package": "shinyjs",


### PR DESCRIPTION
Updating the version of shinycssloaders used in / required by the package, which fixed the bouncy plots issue (#122).